### PR TITLE
Optimize `all`, `any`, make `sum`/`product` more useful

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val commonSettings = Seq(
 
   scalaVersion := "2.12.7",
   crossScalaVersions := Seq(scalaVersion.value, "2.11.12"),
-  scalacOptions += "-Yrangepos",
+  scalacOptions ++= Seq("-Yrangepos", "-language:higherKinds"),
 
   addCompilerPlugin("org.spire-math" % "kind-projector" % kindProjectorV cross CrossVersion.binary),
   addCompilerPlugin("com.olegpy" %% "better-monadic-for" % betterMonadicForV),

--- a/core/src/main/scala/io/chrisdavenport/monoids/All.scala
+++ b/core/src/main/scala/io/chrisdavenport/monoids/All.scala
@@ -6,11 +6,13 @@ import cats.implicits._
 
 final case class All(getAll: Boolean) extends AnyVal
 object All {
-  def all[F[_]: Foldable](fa: F[Boolean]): Boolean = fa.forall(identity)
+  def all[F[_]: Foldable](fa: F[All]): All = All(fa.forall(_.getAll))
+
   implicit val allMonoid: CommutativeMonoid[All] = new CommutativeMonoid[All] {
     val empty: All = All(true)
     def combine(x: All, y: All): All = All(x.getAll && y.getAll)
   }
+
   implicit val allShow: Show[All] = Show.fromToString
   implicit val allOrd: Order[All] = Order.by(_.getAll)
 }

--- a/core/src/main/scala/io/chrisdavenport/monoids/All.scala
+++ b/core/src/main/scala/io/chrisdavenport/monoids/All.scala
@@ -6,11 +6,11 @@ import cats.implicits._
 
 final case class All(getAll: Boolean) extends AnyVal
 object All {
-  def all[F[_]: Foldable](fa: F[Boolean]): Boolean = fa.foldMap(All(_)).getAll
+  def all[F[_]: Foldable](fa: F[Boolean]): Boolean = fa.forall(identity)
   implicit val allMonoid: CommutativeMonoid[All] = new CommutativeMonoid[All] {
-    def empty: All = All(true)
+    val empty: All = All(true)
     def combine(x: All, y: All): All = All(x.getAll && y.getAll)
   }
-  implicit val allShow : Show[All] = Show.fromToString
+  implicit val allShow: Show[All] = Show.fromToString
   implicit val allOrd: Order[All] = Order.by(_.getAll)
 }

--- a/core/src/main/scala/io/chrisdavenport/monoids/Any.scala
+++ b/core/src/main/scala/io/chrisdavenport/monoids/Any.scala
@@ -7,12 +7,12 @@ import cats.implicits._
 final case class Any(getAny: Boolean) extends AnyVal
 object Any {
 
-  def any[F[_]: Foldable](fa: F[Boolean]): Boolean = fa.foldMap(Any(_)).getAny
+  def any[F[_]: Foldable](fa: F[Boolean]): Boolean = fa.exists(identity)
   
   implicit val anyMonoid: CommutativeMonoid[Any] = new CommutativeMonoid[Any]{
-    def empty: Any = Any(false)
-    def combine(x: Any,y: Any): Any = Any(x.getAny || y.getAny)
+    val empty: Any = Any(false)
+    def combine(x: Any, y: Any): Any = Any(x.getAny || y.getAny)
   }
-  implicit val anyShow : Show[Any] = Show.fromToString
+  implicit val anyShow: Show[Any] = Show.fromToString
   implicit val anyOrd: Order[Any] = Order.by(_.getAny)
 }

--- a/core/src/main/scala/io/chrisdavenport/monoids/Any.scala
+++ b/core/src/main/scala/io/chrisdavenport/monoids/Any.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 final case class Any(getAny: Boolean) extends AnyVal
 object Any {
 
-  def any[F[_]: Foldable](fa: F[Boolean]): Boolean = fa.exists(identity)
+  def any[F[_]: Foldable](fa: F[Any]): Any = Any(fa.exists(_.getAny))
   
   implicit val anyMonoid: CommutativeMonoid[Any] = new CommutativeMonoid[Any]{
     val empty: Any = Any(false)

--- a/core/src/main/scala/io/chrisdavenport/monoids/Dual.scala
+++ b/core/src/main/scala/io/chrisdavenport/monoids/Dual.scala
@@ -8,7 +8,7 @@ object Dual extends DualInstances
 
 private[monoids] trait DualInstances extends DualInstances1 {
   implicit def dualMonoid[A: Monoid]: Monoid[Dual[A]] = new Monoid[Dual[A]]{
-    def empty: Dual[A] = Dual(Monoid[A].empty)
+    val empty: Dual[A] = Dual(Monoid[A].empty)
     def combine(x: Dual[A], y: Dual[A]): Dual[A] = 
       Dual(Monoid[A].combine(y.getDual, x.getDual))
   }

--- a/core/src/main/scala/io/chrisdavenport/monoids/Product.scala
+++ b/core/src/main/scala/io/chrisdavenport/monoids/Product.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 
 final case class Product[A](getProduct: A) extends AnyVal
 object Product extends ProductInstances {
-  def product[F[_]: Foldable, A: Numeric](fa: F[A]): A = fa.foldMap(Product(_)).getProduct
+  def product[F[_]: Foldable, A](fa: F[A])(implicit A: Monoid[Product[A]]): A = fa.foldMap(Product(_)).getProduct
 }
 
 private[monoids] trait ProductInstances extends ProductInstances1 {

--- a/core/src/main/scala/io/chrisdavenport/monoids/Sum.scala
+++ b/core/src/main/scala/io/chrisdavenport/monoids/Sum.scala
@@ -5,7 +5,7 @@ import cats.kernel.CommutativeMonoid
 import cats.implicits._
 final case class Sum[A](getSum: A) extends AnyVal
 object Sum extends SumInstances {
-  def sum[F[_]: Foldable, A: Numeric](fa: F[A]): A = fa.foldMap(Sum(_)).getSum
+  def sum[F[_]: Foldable, A](fa: F[A])(implicit A: Monoid[Sum[A]]): A = fa.foldMap(Sum(_)).getSum
 }
 
 private[monoids] trait SumInstances extends SumInstances1 {

--- a/core/src/test/scala/io/chrisdavenport/monoids/AllTests.scala
+++ b/core/src/test/scala/io/chrisdavenport/monoids/AllTests.scala
@@ -18,4 +18,15 @@ class AllTests extends CatsSuite with MonoidsArbitraries {
     List(true, false, true).foldMap(All(_)) shouldEqual All(false)
   }
 
+  test("All.all for true, false, true"){
+    All.all(List(true, false, true).map(All(_))) shouldEqual All(false)
+  }
+
+  test("All.all for true, true, true"){
+    All.all(List(true, true, true).map(All(_))) shouldEqual All(true)
+  }
+
+  test("All.all for false, false"){
+    All.all(List(false, false).map(All(_))) shouldEqual All(false)
+  }
 }

--- a/core/src/test/scala/io/chrisdavenport/monoids/AnyTests.scala
+++ b/core/src/test/scala/io/chrisdavenport/monoids/AnyTests.scala
@@ -18,4 +18,16 @@ class AnyTests extends CatsSuite with MonoidsArbitraries {
     List(false, true, false).foldMap(Any(_)) shouldEqual Any(true)
   }
 
+  test("Any.any for true, false, true"){
+    Any.any(List(true, false, true).map(Any(_))) shouldEqual Any(true)
+  }
+
+  test("Any.any for true, true, true"){
+    Any.any(List(true, true, true).map(Any(_))) shouldEqual Any(true)
+  }
+
+  test("Any.any for false, false"){
+    Any.any(List(false, false).map(Any(_))) shouldEqual Any(false)
+  }
+
 }

--- a/core/src/test/scala/io/chrisdavenport/monoids/DualTests.scala
+++ b/core/src/test/scala/io/chrisdavenport/monoids/DualTests.scala
@@ -20,10 +20,10 @@ class DualTests extends CatsSuite with MonoidsArbitraries {
   }
 
   test("inverse default"){
-      val first = "Hello "
-      val second = "World"
-      val expected = "Hello World"
-      first |+| second shouldEqual expected 
-      (Dual(second) |+| Dual(first)).getDual shouldEqual expected
+    val first = "Hello "
+    val second = "World"
+    val expected = "Hello World"
+    first |+| second shouldEqual expected
+    (Dual(second) |+| Dual(first)).getDual shouldEqual expected
   }
 }

--- a/core/src/test/scala/io/chrisdavenport/monoids/ProductTests.scala
+++ b/core/src/test/scala/io/chrisdavenport/monoids/ProductTests.scala
@@ -22,4 +22,8 @@ class ProductTests extends CatsSuite with MonoidsArbitraries {
   test("multiplication"){
     List(1,2,3,6).foldMap(Product(_)) shouldEqual Product(36)
   }
+
+  test("product"){
+    Product.product(List(1,2,3,6)) shouldEqual 36
+  }
 }

--- a/core/src/test/scala/io/chrisdavenport/monoids/SumTests.scala
+++ b/core/src/test/scala/io/chrisdavenport/monoids/SumTests.scala
@@ -18,7 +18,12 @@ class SumTests extends CatsSuite with MonoidsArbitraries {
     Sum(true).show shouldEqual "Sum(true)"
     Sum(false).show shouldEqual "Sum(false)"
   }
-  test("multiplication"){
+
+  test("addition"){
     List(1,2,3,6).foldMap(Sum(_)) shouldEqual Sum(12)
+  }
+
+  test("sum") {
+    Sum.sum(List(1,2,3,6)) shouldEqual 12
   }
 }


### PR DESCRIPTION
This builds up on #4, making `Sum.sum` and `Product.product` useful for all kinds of `A`s that have `Sum`/`Product` monoids, and not just for those that have a `Numeric`.

Also optimizes `all`/`any` to allow short-circuiting if the underlying Foldable instance is able to do so.